### PR TITLE
Made g_argvs static to avoid segfault when exiting test runs

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -392,7 +392,7 @@ void AssertHelper::operator=(const Message& message) const {
 GTEST_API_ GTEST_DEFINE_STATIC_MUTEX_(g_linked_ptr_mutex);
 
 // A copy of all command line arguments.  Set by InitGoogleTest().
-::std::vector<std::string> g_argvs;
+static ::std::vector<std::string> g_argvs;
 
 ::std::vector<std::string> GetArgvs() {
 #if defined(GTEST_CUSTOM_GET_ARGVS_)

--- a/qpm.json
+++ b/qpm.json
@@ -9,8 +9,8 @@
     "url": "git@github.com:reMarkableAS/googletest.git"
   },
   "version": {
-    "label": "1.0.5",
-    "revision": "qpm/1.0.5"
+    "label": "1.0.6",
+    "revision": "qpm/1.0.6"
   },
   "dependencies": [
   ],


### PR DESCRIPTION
Updated qpm version